### PR TITLE
Added the option to open images loaded from remote URL in the second window(s)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -464,7 +464,7 @@ export default class ImageWindow extends Plugin {
             if (target.localName !== "img") return;
 
             const menu = new Menu();
-            this.addMenuItems(menu, target);
+            this.addMenuItems(menu, target as HTMLImageElement);
 
             menu.showAtPosition({ x: event.pageX, y: event.pageY });
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,6 @@ import {
     Setting,
     TextComponent,
     TFile,
-    View,
     WorkspaceLeaf,
     WorkspaceWindow
 } from "obsidian";

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,7 +187,7 @@ class NamedWindow extends Component {
             this.window.win.electronWindow.setTitle(target.name);
         }
     }
-    
+
     /**
      * Save window position and size under a key specific to the host.  This way,
      * sharing the vault with a second computer with a different monitor layout will not overwrite the
@@ -381,8 +381,7 @@ export default class ImageWindow extends Plugin {
         return document.head.innerHTML;
     }
 
-    addMenuItems(menu: Menu, target:TFile | HTMLImageElement) : void
-    {
+    addMenuItems(menu: Menu, target: TFile | HTMLImageElement): void {
         menu.addItem((item) => {
             item.setTitle("Open in second window")
                 .setIcon("open-elsewhere-glyph")
@@ -424,24 +423,24 @@ export default class ImageWindow extends Plugin {
         this.addSettingTab(new ImageWindowSettingTab(this, this));
 
         // Track right clicks for editor context menu
-        let rightClickTarget:EventTarget = null;
+        let rightClickTarget: EventTarget = null;
         let rightClickOnSameTarget = false;
 
         this.registerDomEvent(document, "mousedown", (event: MouseEvent) => {
             // Check if it's the right button being pushed down
-            if(event.button !== 2) return;
+            if (event.button !== 2) return;
             rightClickTarget = event.target;
         });
-        
+
         this.registerDomEvent(document, "mouseup", (event: MouseEvent) => {
             // Check if it's the right button being lifted
-            if(event.button !== 2 || event.target != rightClickTarget) return;
+            if (event.button !== 2 || event.target != rightClickTarget) return;
             rightClickOnSameTarget = true;
         });
 
         this.registerEvent(
             this.app.workspace.on("file-menu", (menu, file) => {
-                
+
                 if (!(this.app.vault.adapter instanceof FileSystemAdapter))
                     return;
                 if (!(file instanceof TFile)) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,7 @@ class NamedWindow extends Component {
         if (target instanceof TFile)
             await this.leaf.openFile(target, { state: { mode: "preview" } });
         else if (target instanceof HTMLImageElement)
-            await this.leaf.view.contentEl.setChildrenInPlace([target.cloneNode(true)]);
+            this.leaf.view.contentEl.setChildrenInPlace([target.cloneNode(true)]);
 
         this.window.rootEl.querySelector(".status-bar")?.detach();
 
@@ -385,10 +385,7 @@ export default class ImageWindow extends Plugin {
             item.setTitle("Open in second window")
                 .setIcon("open-elsewhere-glyph")
                 .onClick(async () => {
-                    if (target instanceof TFile)
-                        this.defaultWindow.loadFile(target);
-                    else if (target instanceof HTMLImageElement)
-                        this.defaultWindow.loadFile(target);
+                    this.defaultWindow.loadFile(target);
                 });
         });
         for (const [name, record] of Object.entries(
@@ -401,10 +398,7 @@ export default class ImageWindow extends Plugin {
                     .onClick(async () => {
                         const namedWindow = this.windows.get(record.id);
                         if (namedWindow !== undefined) {
-                            if (target instanceof TFile)
-                                namedWindow.loadFile(target);
-                            else if (target instanceof HTMLImageElement)
-                                namedWindow.loadFile(target);
+                            namedWindow.loadFile(target);
                         }
                     });
             });


### PR DESCRIPTION
## Pull Request Description
This PR adds the option to open images from remote URLs in the second windows panes.

## Changes Proposed

- [ ] Added mouse listener events to identify target of editor context menu
- [ ] Added listener to editor context menu that adds "Second Window" options to the context menu if the target was an image.
- [ ] Refactored some code to reduce duplication.

## Screenshots

![image](https://github.com/javalent/second-window/assets/2527318/7ccd1abd-c20d-4731-8732-0c8b321b816a)

